### PR TITLE
Fix to use Included if specified in config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ Metrics/LineLength:
   Exclude:
     - '*.gemspec'
 Metrics/ClassLength:
-  Max: 120
+  Max: 140
 
 # The danger_plugin.rb file presents unique challenges, ignore it.
 Metrics/MethodLength:
@@ -23,4 +23,3 @@ Metrics/AbcSize:
   Enabled: false
 Metrics/CyclomaticComplexity:
   Enabled: false
-

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,3 +23,4 @@ Metrics/AbcSize:
   Enabled: false
 Metrics/CyclomaticComplexity:
   Enabled: false
+

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Current Master
 
-- Utilize included rule when finding files
+- Utilize `included` rule when finding files. See [#79](https://github.com/ashfurrow/danger-ruby-swiftlint/pull/79)
 
 ## 0.11.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Current Master
 
-- Nothing yet!
+- Utilize included rule when finding files
 
 ## 0.11.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Current Master
 
-- Utilize `included` rule when finding files. See [#79](https://github.com/ashfurrow/danger-ruby-swiftlint/pull/79)
+- Utilize `included` rule when finding files. See [#79](https://github.com/ashfurrow/danger-ruby-swiftlint/pull/79).
 
 ## 0.11.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-swiftlint (0.11.0)
+    danger-swiftlint (0.11.1)
       danger
       rake (> 10)
       thor (~> 0.19)
@@ -148,4 +148,4 @@ DEPENDENCIES
   rubocop (~> 0.50.0)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -50,10 +50,10 @@ module Danger
       raise 'swiftlint is not installed' unless swiftlint.installed?
 
       config_file_path = if config_file
-        config_file
-      elsif File.file?('.swiftlint.yml')
-        File.expand_path('.swiftlint.yml')
-      end
+                 config_file
+               elsif File.file?('.swiftlint.yml')
+                 File.expand_path('.swiftlint.yml')
+               end
       log "Using config file: #{config_file_path}"
 
       dir_selected = directory ? File.expand_path(directory) : Dir.pwd

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -153,27 +153,28 @@ module Danger
         # Ensure only files in the selected directory
         select { |file| file.start_with?(dir_selected) }.
         # Reject files excluded on configuration
-        reject do |file|
-          excluded_paths.any? do |excluded_path|
-            Find.find(excluded_path)
-                .map { |excluded_file| Shellwords.escape(excluded_file) }
-                .include?(file)
-          end
-        end.
+        reject { |file| file_exists?(excluded_paths, file) }.
         # Accept files included on configuration
         select do |file|
         next true if included_paths.empty?
-        included_paths.any? do |included_path|
-          Find.find(included_path)
-              .map { |included_file| Shellwords.escape(included_file) }
-              .include?(file)
-        end
+        file_exists?(included_paths, file)
       end
     end
 
     # Get the configuration file
     def load_config(filepath)
       filepath ? YAML.load_file(filepath) : {}
+    end
+
+    # Return whether the file exists within a specified collection of paths
+    #
+    # @return [Bool] file exists within specified collection of paths
+    def file_exists?(paths, file)
+      paths.any? do |path|
+        Find.find(path)
+            .map { |path_file| Shellwords.escape(path_file) }
+            .include?(file)
+      end
     end
 
     # Parses the configuration file and return the specified files in path

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -49,27 +49,34 @@ module Danger
       # Fails if swiftlint isn't installed
       raise 'swiftlint is not installed' unless swiftlint.installed?
 
-      config = if config_file
-                 config_file
-               elsif File.file?('.swiftlint.yml')
-                 File.expand_path('.swiftlint.yml')
-               end
-      log "Using config file: #{config}"
+      config_file_path = if config_file
+        config_file
+      elsif File.file?('.swiftlint.yml')
+        File.expand_path('.swiftlint.yml')
+      end
+      log "Using config file: #{config_file_path}"
 
       dir_selected = directory ? File.expand_path(directory) : Dir.pwd
       log "Swiftlint will be run from #{dir_selected}"
 
+      # Get config
+      config = load_config(config_file_path)
+
       # Extract excluded paths
-      excluded_paths = excluded_files_from_config(config)
+      excluded_paths = format_paths(config['excluded'] || [], config_file_path)
+
+      # Extract included paths
+      included_paths = format_paths(config['included'] || [], config_file_path)
 
       # Extract swift files (ignoring excluded ones)
-      files = find_swift_files(dir_selected, files, excluded_paths)
+      files = find_swift_files(dir_selected, files, excluded_paths, included_paths)
+      log files
       log "Swiftlint will lint the following files: #{files.join(', ')}"
 
       # Prepare swiftlint options
       options = {
         # Make sure we don't fail when config path has spaces
-        config: config ? Shellwords.escape(config) : nil,
+        config: config_file_path ? Shellwords.escape(config_file_path) : nil,
         reporter: 'json',
         quiet: true,
         pwd: dir_selected
@@ -125,7 +132,7 @@ module Danger
     # If files are not provided it will use git modifield and added files
     #
     # @return [Array] swift files
-    def find_swift_files(dir_selected, files = nil, excluded_paths = [])
+    def find_swift_files(dir_selected, files = nil, excluded_paths = [], included_paths = [])
       # Needs to be escaped before comparsion with escaped file paths
       dir_selected = Shellwords.escape(dir_selected)
 
@@ -151,24 +158,33 @@ module Danger
           Find.find(excluded_path)
               .map { |excluded_file| Shellwords.escape(excluded_file) }
               .include?(file)
-        end
+            end
+        end.
+        # Accept files included on configuration
+        select do |file|
+          next true if included_paths.empty?
+          included_paths.any? do |included_path|
+            Find.find(included_path)
+              .map { |included_file| Shellwords.escape(included_file) }
+              .include?(file)
+          end
       end
     end
 
-    # Parses the configuration file and return the excluded files
+    # Get the configuration file
+    def load_config(filepath)
+      if filepath
+        return YAML.load_file(filepath)
+      end
+      return {}
+    end
+
+    # Parses the configuration file and return the specified files in path
     #
-    # @return [Array] list of files excluded
-    def excluded_files_from_config(filepath)
-      config = if filepath
-                 YAML.load_file(filepath)
-               else
-                 { 'excluded' => [] }
-               end
-
-      excluded_paths = config['excluded'] || []
-
-      # Extract excluded paths
-      excluded_paths
+    # @return [Array] list of files specified in path
+    def format_paths(paths, filepath)
+      # Extract included paths
+      paths
         .map { |path| File.join(File.dirname(filepath), path) }
         .map { |path| File.expand_path(path) }
         .select { |path| File.exist?(path) || Dir.exist?(path) }

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -50,10 +50,10 @@ module Danger
       raise 'swiftlint is not installed' unless swiftlint.installed?
 
       config_file_path = if config_file
-                 config_file
-               elsif File.file?('.swiftlint.yml')
-                 File.expand_path('.swiftlint.yml')
-               end
+                           config_file
+                         elsif File.file?('.swiftlint.yml')
+                           File.expand_path('.swiftlint.yml')
+                         end
       log "Using config file: #{config_file_path}"
 
       dir_selected = directory ? File.expand_path(directory) : Dir.pwd
@@ -154,29 +154,26 @@ module Danger
         select { |file| file.start_with?(dir_selected) }.
         # Reject files excluded on configuration
         reject do |file|
-        excluded_paths.any? do |excluded_path|
-          Find.find(excluded_path)
-              .map { |excluded_file| Shellwords.escape(excluded_file) }
-              .include?(file)
-            end
+          excluded_paths.any? do |excluded_path|
+            Find.find(excluded_path)
+                .map { |excluded_file| Shellwords.escape(excluded_file) }
+                .include?(file)
+          end
         end.
         # Accept files included on configuration
         select do |file|
-          next true if included_paths.empty?
-          included_paths.any? do |included_path|
-            Find.find(included_path)
+        next true if included_paths.empty?
+        included_paths.any? do |included_path|
+          Find.find(included_path)
               .map { |included_file| Shellwords.escape(included_file) }
               .include?(file)
-          end
+        end
       end
     end
 
     # Get the configuration file
     def load_config(filepath)
-      if filepath
-        return YAML.load_file(filepath)
-      end
-      return {}
+      filepath ? YAML.load_file(filepath) : {}
     end
 
     # Parses the configuration file and return the specified files in path

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -169,6 +169,22 @@ module Danger
           @swiftlint.lint_files
         end
 
+        it 'lints files in the included paths' do
+          allow(@swiftlint.git).to receive(:added_files).and_return([])
+          allow(@swiftlint.git).to receive(:modified_files).and_return([
+                                                                         'spec/fixtures/SwiftFile.swift',
+                                                                         'spec/fixtures/some_dir/SwiftFile.swift'
+                                                                       ])
+
+          expect_any_instance_of(Swiftlint).to receive(:lint)
+            .with(hash_including(path: File.expand_path('spec/fixtures/SwiftFile.swift')), '')
+            .once
+            .and_return(@swiftlint_response)
+
+          @swiftlint.config_file = 'spec/fixtures/another_config.yml'
+          @swiftlint.lint_files
+        end
+
         it 'does not crash when excluded is nil' do
           allow(@swiftlint.git).to receive(:added_files).and_return([])
           allow(@swiftlint.git).to receive(:modified_files).and_return([
@@ -181,6 +197,21 @@ module Danger
             .and_return(@swiftlint_response)
 
           @swiftlint.config_file = 'spec/fixtures/empty_excluded.yml'
+          @swiftlint.lint_files
+        end
+
+        it 'does not crash when included is nil' do
+          allow(@swiftlint.git).to receive(:added_files).and_return([])
+          allow(@swiftlint.git).to receive(:modified_files).and_return([
+                                                                         'spec/fixtures/SwiftFile.swift'
+                                                                       ])
+
+          expect_any_instance_of(Swiftlint).to receive(:lint)
+            .with(hash_including(path: File.expand_path('spec/fixtures/SwiftFile.swift')), '')
+            .once
+            .and_return(@swiftlint_response)
+
+          @swiftlint.config_file = 'spec/fixtures/empty_included.yml'
           @swiftlint.lint_files
         end
 

--- a/spec/fixtures/another_config.yml
+++ b/spec/fixtures/another_config.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - todo
+
+included:
+  - SwiftFile.swift
+
+excluded:
+  - an/excluded/folder

--- a/spec/fixtures/empty_included.yml
+++ b/spec/fixtures/empty_included.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - todo
+
+included:
+
+
+excluded:
+  - an/excluded/folder


### PR DESCRIPTION
This PR addresses the fact that the `included` rule in the configuration isn't being utilized.  Currently only the `excluded` rule is used.  This causes a YAML file used in SwiftLint (that makes use of `included`) to not fully work as expected when using this plugin.

**Problem:** Files are only excluded from linting, they cannot be explicitly included.

**Solution:** In `find_swift_files` include files specified in `included`, after files have been excluded.