### PR TITLE
Removes Changelog check #trivial

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -7,9 +7,4 @@ warn("PR is classed as Work in Progress") if github.pr_title.include? "[WIP]"
 
 warn("Big PR, try to keep changes smaller if you can") if git.lines_of_code > 500
 
-no_changelog_entry = !git.modified_files.include?("Changelog.md")
-if has_app_changes && no_changelog_entry
-  warn("Any changes to library code should be reflected in the Changelog. Please consider adding a note there.")
-end
-
 rubocop.lint


### PR DESCRIPTION
No longer required, as of https://github.com/ashfurrow/peril-settings/blob/d8fa6956ada312ef6f4748fa4f21ca82e065777b/rules/all-prs.ts#L12-L39 . See https://github.com/ashfurrow/danger-ruby-swiftlint/pull/80.