### PR TITLE
Fix `swiftlint.directory` code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ swiftlint.lint_files inline_mode: true
 If you want different configurations on different directories, you can specify the directory. Note: Run `swiftlint.lint_files` per specified directory then.
 
 ```rb
-swiftlint.directory "Directory A"
+swiftlint.directory = "Directory A"
 ```
 
 If you want lint errors to fail Danger, you can use `fail_on_error` option.


### PR DESCRIPTION
I encountered a problem with the code.
```
Danger::DSLError: 
[!] Invalid `dangerfile.rb` file: wrong number of arguments (given 1, expected 0)
#  from dangerfile.rb:1
#  -------------------------------------------
>  swiftlint.directory "."
#  swiftlint.lint_files inline_mode: true
```
