### PR TITLE
Set minimum required Ruby version to 2.3

### DIFF
--- a/danger-swiftlint.gemspec
+++ b/danger-swiftlint.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.extensions    = %w[ext/swiftlint/Rakefile]
   spec.executables   = ['danger-swiftlint']
+  spec.required_ruby_version = '>= 2.3'
 
   spec.add_dependency 'danger'
   spec.add_dependency 'thor', '~> 0.19'


### PR DESCRIPTION
- the frozen_string_literal changes in f9c5674 were only added in Ruby 2.3, so we got a `undefined method '+@' for "### SwiftLint found
issues\n\n":String` error when our CI box tried to run it on Ruby 2.2
- heres a good article about those string literal changes, they do seem neat-o
https://wyeworks.com/blog/2015/12/1/immutable-strings-in-ruby-2-dot-3