### PR TITLE
edit rakefile to run spec task #trivial

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,11 +5,4 @@ require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
-
-task default: :spec
-
-task :spec do
-  Rake::Task['specs'].invoke
-end
-
 task default: :spec


### PR DESCRIPTION
There is no `specs` task, which was being attempted to be run.
Fixes #92 

Tests now run with `bundle exec rake spec` too.