### PR TITLE
Fix inline mode behavior for fail_on_error

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Current Master
 
-- Nothing yet!
+- Respect `fail_on_error` when `inline_mode` is true. See [#91](https://github.com/ashfurrow/danger-ruby-swiftlint/issues/91).
 
 ## 0.14.0
 

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -99,7 +99,7 @@ module Danger
       if inline_mode
         # Report with inline comment
         send_inline_comment(warnings, 'warn')
-        send_inline_comment(errors, 'fail')
+        send_inline_comment(errors, fail_on_error ? 'fail' : 'warn')
         warn other_issues_message(other_issues_count) if other_issues_count > 0
       elsif warnings.count > 0 || errors.count > 0
         # Report if any warning or error

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -282,16 +282,39 @@ module Danger
           @swiftlint.lint_files
         end
 
-        it 'generates errors instead of markdown when use inline mode' do
+        it 'generates errors/warnings instead of markdown when use inline mode' do
+          allow_any_instance_of(Swiftlint).to receive(:lint)
+            .with(hash_including(path: File.expand_path('spec/fixtures/SwiftFile.swift')), '')
+            .and_return(@swiftlint_response)
+
+          @swiftlint.lint_files('spec/fixtures/*.swift', inline_mode: true, additional_swiftlint_args: '')
+
+          status = @swiftlint.status_report
+          expect(status[:errors] + status[:warnings]).to_not be_empty
+          expect(status[:markdowns]).to be_empty
+        end
+
+        it 'generate errors in inline_mode when fail_on_error' do
+          allow_any_instance_of(Swiftlint).to receive(:lint)
+            .with(hash_including(path: File.expand_path('spec/fixtures/SwiftFile.swift')), '')
+            .and_return(@swiftlint_response)
+
+          @swiftlint.lint_files('spec/fixtures/*.swift', inline_mode: true, fail_on_error: true, additional_swiftlint_args: '')
+          
+          status = @swiftlint.status_report
+          expect(status[:errors]).to_not be_empty
+        end
+
+        it 'generate only warnings in inline_mode when fail_on_error is false' do
           allow_any_instance_of(Swiftlint).to receive(:lint)
             .with(hash_including(path: File.expand_path('spec/fixtures/SwiftFile.swift')), '')
             .and_return(@swiftlint_response)
 
           @swiftlint.lint_files('spec/fixtures/*.swift', inline_mode: true, fail_on_error: false, additional_swiftlint_args: '')
-
+          
           status = @swiftlint.status_report
-          expect(status[:errors]).to_not be_empty
-          expect(status[:markdowns]).to be_empty
+          expect(status[:warnings]).to_not be_empty
+          expect(status[:errors]).to be_empty
         end
       end
     end


### PR DESCRIPTION
Fixes #91 

This is a breaking change, since the default value for `fail_on_error` is false.
People working with `inline_mode: true` will have to set `fail_on_error: true` to get the previous behavior.