### PR TITLE
Send refactor

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,6 @@ Metrics/CyclomaticComplexity:
 # For Ruby 2.2 compatibility
 Style/NumericPredicate:
   Enabled: false
+
+Style/SignalException:
+  Enabled: false

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,8 @@
 
 ## Current Master
 
-- Respect `fail_on_error` when `inline_mode` is true. See [#91](https://github.com/ashfurrow/danger-ruby-swiftlint/issues/91).
+- **Breaking Change**: for anyone using `inline_mode: true`, we now respect `fail_on_error`, which is `false` by default. Set `fail_on_error: true` to restore previous behaviour. See [#91](https://github.com/ashfurrow/danger-ruby-swiftlint/issues/91).
+- Refactors to use symbols instead of strings for `send` function.
 
 ## 0.14.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-swiftlint (0.11.1)
+    danger-swiftlint (0.14.0)
       danger
       rake (> 10)
       thor (~> 0.19)

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -98,8 +98,8 @@ module Danger
 
       if inline_mode
         # Report with inline comment
-        send_inline_comment(warnings, 'warn')
-        send_inline_comment(errors, fail_on_error ? 'fail' : 'warn')
+        send_inline_comment(warnings, :warn)
+        send_inline_comment(errors, fail_on_error ? :fail : :warn)
         warn other_issues_message(other_issues_count) if other_issues_count > 0
       elsif warnings.count > 0 || errors.count > 0
         # Report if any warning or error

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -300,7 +300,7 @@ module Danger
             .and_return(@swiftlint_response)
 
           @swiftlint.lint_files('spec/fixtures/*.swift', inline_mode: true, fail_on_error: true, additional_swiftlint_args: '')
-          
+
           status = @swiftlint.status_report
           expect(status[:errors]).to_not be_empty
         end
@@ -311,7 +311,7 @@ module Danger
             .and_return(@swiftlint_response)
 
           @swiftlint.lint_files('spec/fixtures/*.swift', inline_mode: true, fail_on_error: false, additional_swiftlint_args: '')
-          
+
           status = @swiftlint.status_report
           expect(status[:warnings]).to_not be_empty
           expect(status[:errors]).to be_empty


### PR DESCRIPTION
We currently use strings (either `'warn'` or `'fail'`) when invoking `send`, here:

https://github.com/ashfurrow/danger-ruby-swiftlint/blob/3619427939d53b51898f34dffb229889b7c0bd90/lib/danger_plugin.rb#L218

Ruby prefers to use symbols instead of strings, and indeed `send` will accept either. See section 1.3.2 of [these docs](http://ruby-metaprogramming.rubylearning.com/html/ruby_metaprogramming_2.html). This PR just uses symbols instead of strings. It also corrects a few Rubocop violations.