### PR TITLE
Add logging for excluded and included paths

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Current Master
 
-- Nothing yet!
+- Added logging for excluded and included paths to improve debugging this functionality. 
 
 ## 0.15.0
 

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -65,8 +65,12 @@ module Danger
       # Extract excluded paths
       excluded_paths = format_paths(config['excluded'] || [], config_file_path)
 
+      log "Swiftlint will exclude the following paths: #{excluded_paths}"
+
       # Extract included paths
       included_paths = format_paths(config['included'] || [], config_file_path)
+
+      log "Swiftlint includes the following paths: #{included_paths}"
 
       # Extract swift files (ignoring excluded ones)
       files = find_swift_files(dir_selected, files, excluded_paths, included_paths)


### PR DESCRIPTION
While debugging your Swiftlint config files, it's sometimes quite hard to get the right paths and see if excluding and including is working as expected. These two log files would have helped me a lot and are a nice addition to our verbose logging setup. 