### PR TITLE
Add support for environment variables in Swiftlint configs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+- Add support for Environment variables which are supported in Swiftlint since [0.21.0](https://github.com/realm/SwiftLint/releases/tag/0.21.0) (See https://github.com/realm/SwiftLint/issues/1512). 
 - Added logging for excluded and included paths to improve debugging this functionality. 
 - Removed unneeded extra files logging in while using verbose
 

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -178,8 +178,10 @@ module Danger
 
     # Find all requested environment variables in the given string and replace them with the correct values.
     def parse_environment_variables(file_contents)
-      file_contents.gsub(/\$\{([^{}]+)\}/) do |environment_variable|
-        return environment_variable if ENV[Regexp.last_match[1]].nil?
+      # Matches the file contents for environment variables defined like ${VAR_NAME}.
+      # Replaces them with the environment variable value if it exists.
+      file_contents.gsub(/\$\{([^{}]+)\}/) do |env_var|
+        return env_var if ENV[Regexp.last_match[1]].nil?
         ENV[Regexp.last_match[1]]
       end
     end

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -62,8 +62,6 @@ module Danger
       # Get config
       config = load_config(config_file_path)
 
-      log "Config succesfully loaded with excluded paths #{config['excluded'] || []}"
-
       # Extract excluded paths
       excluded_paths = format_paths(config['excluded'] || [], config_file_path)
 

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -166,22 +166,22 @@ module Danger
 
     # Get the configuration file
     def load_config(filepath)
-      return {} unless !filepath.nil?
-      return {} unless File.exists?(filepath)
-
+      return {} if filepath.nil? || !File.exist?(filepath)
+      
       config_file = File.open(filepath).read
 
       # Replace environment variables
       config_file = parse_environment_variables(config_file)
 
-      YAML.load(config_file)
+      YAML.safe_load(config_file)
     end
 
     # Find all requested environment variables in the given string and replace them with the correct values.
     def parse_environment_variables(file_contents)
-      file_contents.gsub(/\$\{([^{}]+)\}/) { | environment_variable |
-        environment_variable = ENV[$1] || ""
-      }
+      file_contents.gsub(/\$\{([^{}]+)\}/) do |environment_variable|
+        return environment_variable if ENV[Regexp.last_match[1]].nil?
+        ENV[Regexp.last_match[1]]
+      end
     end
 
     # Return whether the file exists within a specified collection of paths

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -167,7 +167,7 @@ module Danger
     # Get the configuration file
     def load_config(filepath)
       return {} if filepath.nil? || !File.exist?(filepath)
-      
+
       config_file = File.open(filepath).read
 
       # Replace environment variables

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -62,6 +62,8 @@ module Danger
       # Get config
       config = load_config(config_file_path)
 
+      log "Config succesfully loaded with excluded paths #{config['excluded'] || []}"
+
       # Extract excluded paths
       excluded_paths = format_paths(config['excluded'] || [], config_file_path)
 
@@ -167,7 +169,22 @@ module Danger
 
     # Get the configuration file
     def load_config(filepath)
-      filepath ? YAML.load_file(filepath) : {}
+      return {} unless !filepath.nil?
+      return {} unless File.exists?(filepath)
+
+      config_file = File.open(filepath).read
+
+      # Replace environment variables
+      config_file = parse_environment_variables(config_file)
+
+      YAML.load(config_file)
+    end
+
+    # Find all requested environment variables in the given string and replace them with the correct values.
+    def parse_environment_variables(file_contents)
+      file_contents.gsub(/\$\{([^{}]+)\}/) { | environment_variable |
+        environment_variable = ENV[$1] || ""
+      }
     end
 
     # Return whether the file exists within a specified collection of paths

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -44,6 +44,10 @@ module Danger
           @swiftlint_response = '[{ "rule_id" : "force_cast", "reason" : "Force casts should be avoided.", "character" : 19, "file" : "/Users/me/this_repo/spec//fixtures/SwiftFile.swift", "severity" : "Error", "type" : "Force Cast", "line" : 13 }]'
         end
 
+        after(:each) do
+          ENV['ENVIRONMENT_EXAMPLE'] = nil
+        end
+
         it 'accept files as arguments' do
           expect_any_instance_of(Swiftlint).to receive(:lint)
             .with(hash_including(path: File.expand_path('spec/fixtures/SwiftFile.swift')), '')
@@ -336,8 +340,6 @@ module Danger
 
           @swiftlint.config_file = 'spec/fixtures/environment_variable_config.yml'
           @swiftlint.lint_files
-
-          ENV['ENVIRONMENT_EXAMPLE'] = nil
         end
       end
     end

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -235,7 +235,9 @@ module Danger
                                                                          'spec/fixtures/SwiftFile.swift'
                                                                        ])
           expect(File).to receive(:file?).and_return(true)
-          expect(YAML).to receive(:load_file).and_return({})
+          expect(File).to receive(:exists?).and_return(true)
+          expect(File).to receive(:open).and_return(StringIO.new())
+          expect(YAML).to receive(:load).and_return({})
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
             .with(hash_including(config: File.expand_path('.swiftlint.yml')), '')

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -235,9 +235,9 @@ module Danger
                                                                          'spec/fixtures/SwiftFile.swift'
                                                                        ])
           expect(File).to receive(:file?).and_return(true)
-          expect(File).to receive(:exists?).and_return(true)
-          expect(File).to receive(:open).and_return(StringIO.new())
-          expect(YAML).to receive(:load).and_return({})
+          expect(File).to receive(:exist?).and_return(true)
+          expect(File).to receive(:open).and_return(StringIO.new)
+          expect(YAML).to receive(:safe_load).and_return({})
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
             .with(hash_including(config: File.expand_path('.swiftlint.yml')), '')
@@ -320,8 +320,8 @@ module Danger
         end
 
         it 'parses environment variables set within the swiftlint config' do
-          ENV["ENVIRONMENT_EXAMPLE"] = "excluded_dir"
-          
+          ENV['ENVIRONMENT_EXAMPLE'] = 'excluded_dir'
+
           allow(@swiftlint.git).to receive(:added_files).and_return([])
           allow(@swiftlint.git).to receive(:modified_files).and_return([
                                                                          'spec/fixtures/SwiftFile.swift',
@@ -337,7 +337,7 @@ module Danger
           @swiftlint.config_file = 'spec/fixtures/environment_variable_config.yml'
           @swiftlint.lint_files
 
-          ENV["ENVIRONMENT_EXAMPLE"] = nil
+          ENV['ENVIRONMENT_EXAMPLE'] = nil
         end
       end
     end

--- a/spec/fixtures/environment_variable_config.yml
+++ b/spec/fixtures/environment_variable_config.yml
@@ -1,0 +1,8 @@
+disabled_rules:
+  - todo
+
+included:
+  - an/included/folder
+
+excluded:
+  - ${ENVIRONMENT_EXAMPLE}


### PR DESCRIPTION
Swiftlint configs support environment variables since [0.21.0](https://github.com/realm/SwiftLint/releases/tag/0.21.0) (See https://github.com/realm/SwiftLint/issues/1512). 

As we were filtering out excluded and included paths if they didn't exist on disk, environment variables would not reach Swiftlint and would not get parsed. With this PR we're implementing support for environment variables just like Swiftlint.

An example usage can be found here, where we use it with WeTransfer to reuse config files across repositories: https://github.com/WeTransfer/WeTransfer-iOS-CI/blob/master/SwiftLint/.swiftlint-source.yml#L50
