### PR TITLE
Updates SwiftLint, adds force-excludes option.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## Current Master
-- Nothing yet!
+
+- Updates to SwiftLint 0.25.1.
+- Forces exclusion for files specified as excluded in `.swiftlint.yml`. (See [#87](https://github.com/ashfurrow/danger-ruby-swiftlint/issues/87).)
 
 ## 0.16.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-swiftlint (0.14.0)
+    danger-swiftlint (0.16.0)
       danger
       rake (> 10)
       thor (~> 0.19)

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -82,7 +82,8 @@ module Danger
         config: config_file_path ? Shellwords.escape(config_file_path) : nil,
         reporter: 'json',
         quiet: true,
-        pwd: dir_selected
+        pwd: dir_selected,
+        force_exclude: ''
       }
       log "linting with options: #{options}"
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,5 +2,5 @@
 
 module DangerSwiftlint
   VERSION = '0.16.0'
-  SWIFTLINT_VERSION = '0.25.0'
+  SWIFTLINT_VERSION = '0.25.1'
 end

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -48,6 +48,18 @@ module Danger
           ENV['ENVIRONMENT_EXAMPLE'] = nil
         end
 
+        it 'specifies --force-exclude when invoking SwiftLint' do
+          expect_any_instance_of(Swiftlint).to receive(:lint)
+            .with(hash_including(force_exclude: ''), '')
+            .and_return(@swiftlint_response)
+
+          @swiftlint.lint_files('spec/fixtures/*.swift')
+
+          output = @swiftlint.status_report[:markdowns].first.to_s
+          expect(output).to include('SwiftLint found issues')
+          expect(output).to include('SwiftFile.swift | 13 | Force casts should be avoided.')
+        end
+
         it 'accept files as arguments' do
           expect_any_instance_of(Swiftlint).to receive(:lint)
             .with(hash_including(path: File.expand_path('spec/fixtures/SwiftFile.swift')), '')


### PR DESCRIPTION
This uses the new `--force-excludes` flag that SwiftLint added in 0.25.1.

Fixes #87.