### PR TITLE
Fix use of return in native extension Rakefile

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,8 @@
 
 ## Current Master
 
-- Nothing yet!
+- Fix use of `return` in native extension `Rakefile`. See [#106](https://github.com/ashfurrow/danger-ruby-swiftlint/issues/106).
+- Add `DANGER_` prefix to `DANGER_SKIP_SWIFTLINT_INSTALL`. See [#106](https://github.com/ashfurrow/danger-ruby-swiftlint/issues/106).
 
 ## 0.17.2
 

--- a/ext/swiftlint/Rakefile
+++ b/ext/swiftlint/Rakefile
@@ -5,7 +5,7 @@ require_relative '../../lib/version'
 namespace :swiftlint do
   desc 'Download and install swiftlint tool'
   task :install do
-    return if ENV['SKIP_SWIFTLINT_INSTALL'] == 'YES'
+    next if ENV['DANGER_SKIP_SWIFTLINT_INSTALL'] == 'YES'
 
     REPO = 'https://github.com/realm/SwiftLint'
     VERSION = ENV['SWIFTLINT_VERSION'] || DangerSwiftlint::SWIFTLINT_VERSION


### PR DESCRIPTION
This is a follow up and patch for #106 and #107.

While trying to install the `0.17.2` I got this error:

```
rake aborted!
LocalJumpError: unexpected return
```

So this fixes use of `return` and replaces it with `next`.

Also I've added `DANGER_` prefix to the `DANGER_SKIP_SWIFTLINT_INSTALL` environment variable, so it's namespaced and has less chances of conflicting with some other tool's env vars.

P.S.

This time I _did_ test the changes :)

```ruby
# Gemfile

# ***

gem "danger-swiftlint", git: "https://github.com/mgrebenets/danger-ruby-swiftlint.git", branch: "fix-return-in-rakefile"
```

Then did `bundle install` with and without `DANGER_SKIP_SWIFTLINT_INSTALL` set to confirm that SwiftLint is/is not downloaded:

```shell
DANGER_SKIP_SWIFTLINT_INSTALL=YES bundle install
# vs
bundle install
```