### PR TITLE
Update SwiftLint and changelog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@
 
 - Nothing yet!
 
+## 0.17.5
+- Updates to SwiftLint [0.28.1](https://github.com/realm/SwiftLint/releases/tag/0.28.1).
+
 ## 0.17.4
 - Updates to SwiftLint [0.27.0](https://github.com/realm/SwiftLint/releases/tag/0.27.0). 
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module DangerSwiftlint
-  VERSION = '0.17.4'
+  VERSION = '0.17.5'
   SWIFTLINT_VERSION = '0.28.1'
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,5 +2,5 @@
 
 module DangerSwiftlint
   VERSION = '0.17.4'
-  SWIFTLINT_VERSION = '0.27.0'
+  SWIFTLINT_VERSION = '0.28.1'
 end


### PR DESCRIPTION
- bump Swiftlint to version 0.28.1 to support new Swift 4.2 opt-in rules
- update changelog to reflect this bump and prepare for new release

Also - it would be nice to migrate to CircleCI 2.0 from 1.0. :)