### PR TITLE
#trivial Fixes specifying --force-exclude option

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Current Master
 
-- Nothing yet!
+- Fixes incorrect specifying of the `--force-exclude` option, which leads to the ```No lintable files found at path``` error. See [#87](https://github.com/ashfurrow/danger-ruby-swiftlint/issues/87) discussion.
 
 ## 0.18.1
 

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -86,7 +86,7 @@ module Danger
         reporter: 'json',
         quiet: true,
         pwd: dir_selected,
-        force_exclude: ''
+        force_exclude: true
       }
       log "linting with options: #{options}"
 

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -50,7 +50,7 @@ module Danger
 
         it 'specifies --force-exclude when invoking SwiftLint' do
           expect_any_instance_of(Swiftlint).to receive(:lint)
-            .with(hash_including(force_exclude: ''), '')
+            .with(hash_including(force_exclude: true), '')
             .and_return(@swiftlint_response)
 
           @swiftlint.lint_files('spec/fixtures/*.swift')


### PR DESCRIPTION
Currently **--force-exclude** option is being specified with an empty string value, while it has to have no value. This leads to the ```No lintable files found at path``` error.

See https://github.com/ashfurrow/danger-ruby-swiftlint/issues/87 discussion.

#trivial