### PR TITLE
Add rule_id and filename:line to github comment

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -237,7 +237,6 @@ module Danger
         rule = r['rule_id']
         # Other available properties can be found int SwiftLint/…/JSONReporter.swift
         message << "#{filename} | #{line} | #{reason} (#{rule})\n"
-        message << "#{filename} | #{line}"
       end
 
       message

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -247,8 +247,15 @@ module Danger
     def send_inline_comment(results, method)
       dir = "#{Dir.pwd}/"
       results.each do |r|
-        filename = r['file'].gsub(dir, '')
-        send(method, r['reason'], file: filename, line: r['line'])
+        github_filename = r['file'].gsub(dir, '')
+        message = "#{r['reason']}"
+
+        # extended content here
+        filename = File.basename(r['file'])
+        message << "\n"
+        message << "#{r['file']}:#{r['line']}" # file:line for copying into Xcode quick open
+        message << " #{r['rule_id'] }" # rule identifier, helps writing exceptions // swiftlint:disable:this rule_id
+        send(method, message, file: github_filename, line: r['line'])
       end
     end
 

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -251,7 +251,7 @@ module Danger
         message = "#{r['reason']}"
 
         # extended content here
-        filename = File.basename(r['file'])
+        filename = r['file'].split('/').last
         message << "\n"
         message << "#{r['file']}:#{r['line']}" # file:line for copying into Xcode quick open
         message << " #{r['rule_id'] }" # rule identifier, helps writing exceptions // swiftlint:disable:this rule_id

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -255,8 +255,9 @@ module Danger
         # extended content here
         filename = r['file'].split('/').last
         message << "\n"
-        message << "#{filename}:#{r['line']}" # file:line for copying into Xcode quick open
-        message << " #{r['rule_id'] }" # rule identifier, helps writing exceptions // swiftlint:disable:this rule_id
+        message << "`#{r['rule_id']}`" # helps writing exceptions // swiftlint:disable:this rule_id
+        message << " `#{filename}:#{r['line']}`" # file:line for pasting into Xcode Quick Open
+        
         send(method, message, file: github_filename, line: r['line'])
       end
     end

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -234,8 +234,10 @@ module Danger
         filename = r['file'].split('/').last
         line = r['line']
         reason = r['reason']
-
-        message << "#{filename} | #{line} | #{reason} \n"
+        rule = r['rule_id']
+        # Other available properties can be found int SwiftLint/…/JSONReporter.swift
+        message << "#{filename} | #{line} | #{reason} (#{rule})\n"
+        message << "#{filename} | #{line}"
       end
 
       message

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -248,12 +248,12 @@ module Danger
       dir = "#{Dir.pwd}/"
       results.each do |r|
         github_filename = r['file'].gsub(dir, '')
-        message = "#{r['reason']}"
+        message = "#{r['reason']}".dup
 
         # extended content here
         filename = r['file'].split('/').last
         message << "\n"
-        message << "#{r['file']}:#{r['line']}" # file:line for copying into Xcode quick open
+        message << "#{filename}:#{r['line']}" # file:line for copying into Xcode quick open
         message << " #{r['rule_id'] }" # rule identifier, helps writing exceptions // swiftlint:disable:this rule_id
         send(method, message, file: github_filename, line: r['line'])
       end

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -57,7 +57,7 @@ module Danger
 
           output = @swiftlint.status_report[:markdowns].first.to_s
           expect(output).to include('SwiftLint found issues')
-          expect(output).to include('SwiftFile.swift | 13 | Force casts should be avoided.')
+          expect(output).to include('SwiftFile.swift | 13 | Force casts should be avoided. (force_cast)')
         end
 
         it 'accept files as arguments' do
@@ -69,7 +69,7 @@ module Danger
 
           output = @swiftlint.status_report[:markdowns].first.to_s
           expect(output).to include('SwiftLint found issues')
-          expect(output).to include('SwiftFile.swift | 13 | Force casts should be avoided.')
+          expect(output).to include('SwiftFile.swift | 13 | Force casts should be avoided. (force_cast)')
         end
 
         it 'sets maxium number of violations' do
@@ -83,9 +83,9 @@ module Danger
 
           output = @swiftlint.status_report[:markdowns].first.to_s
           expect(output).to include('SwiftLint found issues')
-          expect(output).to include('SwiftFile.swift | 13 | Force casts should be avoided.')
+          expect(output).to include('SwiftFile.swift | 13 | Force casts should be avoided. (force_cast)')
           expect(output).to include('SwiftLint also found 1 more violation with this PR.')
-          expect(output).to_not include('SwiftFile.swift | 14 | Force casts should be avoided.')
+          expect(output).to_not include('SwiftFile.swift | 14 | Force casts should be avoided. (force_cast)')
         end
 
         it 'accepts additional cli arguments' do

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -312,6 +312,17 @@ module Danger
           expect(status[:markdowns]).to be_empty
         end
 
+        it 'renders rule_id and file:line indicators in inline mode' do
+          allow_any_instance_of(Swiftlint).to receive(:lint)
+            .with(hash_including(path: File.expand_path('spec/fixtures/SwiftFile.swift')), '')
+            .and_return(@swiftlint_response)
+
+          @swiftlint.lint_files('spec/fixtures/*.swift', inline_mode: true, additional_swiftlint_args: '')
+
+          status = @swiftlint.status_report          
+          expect(status[:warnings]).to eql(["Force casts should be avoided.\n`force_cast` `SwiftFile.swift:13`"])
+        end
+
         it 'generate errors in inline_mode when fail_on_error' do
           allow_any_instance_of(Swiftlint).to receive(:lint)
             .with(hash_including(path: File.expand_path('spec/fixtures/SwiftFile.swift')), '')


### PR DESCRIPTION
# Overall Goal
Make it easier to open and fix/disable the swiftlint issue in Xcode.

## Rule ID
When looking at a swiftlint issue, it is helpful to see which `rule_id` it is.

This can be used to then work around false positives using `// swiftlint:disable:next rule_id` or similar code comments.

## Xcode Filepath
When looking at an issue and wanting to open that location in Xcode, it is helpful to have a
`File:Line` reference to copy. This can be pasted in Xcode which navigates to that file at that line.

This should improve the workflow when looking at an issue on github and fixing it in Xcode.
I wrapped both in `verbatim` so they are visually easy to find and easily selectable with the cursor.

## Result
<img width="737" alt="bildschirmfoto 2019-02-21 um 15 12 05" src="https://user-images.githubusercontent.com/1856655/53175010-6a637380-35eb-11e9-8273-b9a1e3c7e66f.png">


# Considerations
Should this be made optional? If so, where would this best be configured?

In markdown I just added (rule_id) as non-verbatim suffix, As I would expect verbatiming and file:line-ing to cause too much visual noise.