### PR TITLE
Update SwiftLint version to 0.31.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@
 
 - Nothing yet!
 
+## 0.19.1
+
+- Updates to SwiftLint [0.31.0](https://github.com/realm/SwiftLint/releases/tag/0.31.0). 
+
 ## 0.19.0
 
 - Adds the rule ID and filename:line to GitHub comments. See [#122](https://github.com/ashfurrow/danger-ruby-swiftlint/pull/122).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-swiftlint (0.19.0)
+    danger-swiftlint (0.19.1)
       danger
       rake (> 10)
       thor (~> 0.19)
@@ -148,4 +148,4 @@ DEPENDENCIES
   rubocop (~> 0.50.0)
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module DangerSwiftlint
-  VERSION = '0.19.0'
-  SWIFTLINT_VERSION = '0.28.1'
+  VERSION = '0.19.1'
+  SWIFTLINT_VERSION = '0.31.0'
 end


### PR DESCRIPTION
## What's the problem?

Like reported on #123 I have been having problems trying to force the environment variable `SWIFTLINT_VERSION`.

Locally I use the latest version of Danger (0.31.0), which includes new rules.
When running on CI it installs the plugin default (0.28.1) and fails because it doesn't recognise the new rules.

Since I haven't been able to force the version, one alternative would be to manually bump the default version on the plugin.

## What this PR does

* Bumps the `SWIFTLINT_VERSION` to '0.31.0'
* Bumps the Spec patch version to '0.19.1'
* Adds the changes in the Changelog

Thanks for building this plugin 👍🏻
Francisco