### PR TITLE
Fix gem installation when installation path contains spaces

### DIFF
--- a/ext/swiftlint/Rakefile
+++ b/ext/swiftlint/Rakefile
@@ -15,9 +15,9 @@ namespace :swiftlint do
 
     puts "Downloading swiftlint@#{VERSION}"
     sh [
-      "mkdir -p #{DESTINATION}",
+      "mkdir -p '#{DESTINATION}'",
       "curl -s -L #{URL} -o #{ASSET}",
-      "unzip -q #{ASSET} -d #{DESTINATION}",
+      "unzip -q #{ASSET} -d '#{DESTINATION}'",
       "rm #{ASSET}"
     ].join(' && ')
   end


### PR DESCRIPTION
Summary
-------
A standard local installation of the `danger-swiftlint` gem will fail if spaces exist in the installation path.

Example:

**Path:** ~/Desktop/Folder With Spaces/.
**Gemfile:**
```
source 'https://rubygems.org'

gem 'danger-swiftlint'
```

Running `bundle install --path .bundle` will incur a build failure within the native extension 

Implementation
-------
The issue occurs due to unescaped spaces being interpreted as bash argument delimiters in the swiftlint extension. This simply wraps the captured `DESTINATION` in the Rakefile for the swiftlint extension.

## Testing
Using the above example:
1. Locally check out this branch
2. Update the gemfile:
```
source 'https://rubygems.org'

gem 'danger-swiftlint', :path => '/path/to/local/gem'
```
3. Run `bundle install --path .bundle`