### PR TITLE
Implement generic violation select block

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ swiftlint.lint_all_files = true
 swiftlint.lint_files
 ```
 
+It's also possible to pass a block to filter out any violations after swiftlint has been run. Here's an example filtering out all violations that didn't occur in the current github PR, using the third party gem `git_diff_parser`:
+
+```ruby
+require 'git_diff_parser'
+
+diff = GitDiffParser::Patches.parse(github.pr_diff)
+dir = "#{Dir.pwd}/"
+swiftlint.lint_files(inline_mode: true) { |violation|
+  diff_filename = violation['file'].gsub(dir, '')
+  file_patch = diff.find_patch_by_file(diff_filename)
+  file_patch != nil && file_patch.changed_lines.any? { |line| line.number == violation['line']}
+}
+```
+
 You can use the `SWIFTLINT_VERSION` environment variable to override the default version installed via the `rake install` task.
 
 Finally, if something's not working correctly, you can debug this plugin by using setting `swiftlint.verbose = true`.

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -48,7 +48,7 @@ module Danger
     #          if nil, modified and added files from the diff will be used.
     # @return  [void]
     #
-    def lint_files(files = nil, inline_mode: false, fail_on_error: false, additional_swiftlint_args: '')
+    def lint_files(files = nil, inline_mode: false, fail_on_error: false, additional_swiftlint_args: '', &select_block)
       # Fails if swiftlint isn't installed
       raise 'swiftlint is not installed' unless swiftlint.installed?
 
@@ -98,6 +98,11 @@ module Danger
         issues = issues.take(@max_num_violations)
       end
       log "Received from Swiftlint: #{issues}"
+      
+      # filter out any unwanted violations with the passed in select_block
+      if select_block
+        issues.select! { |issue| select_block.call(issue) }
+      end
 
       # Filter warnings and errors
       warnings = issues.select { |issue| issue['severity'] == 'Warning' }


### PR DESCRIPTION
- A take at implementing #125 
- First implementation I added a git diff parser and filtered out lines that weren't in the diff, but didn't like how it changed the code here. I ended up on setting for a generic `select_block` approach that allows any consumer of this library to filter out violations before they are sent back to danger.
- @ashfurrow please take a look, I'm open to changing the approach if it doesn't feel quite right too (as I don't have much experience with blocks/Procs) thanks!