### PR TITLE
Implement 'no_comment' parameter to allow manual handling of swiftlint results

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ swiftlint.lint_files(inline_mode: true) { |violation|
 }
 ```
 
+Or, by passing the `no_comment` parameter, you can completely manage the commenting of issues, warnings and errors yourself. An example usage might be using github reviews, or custom filtering logic. Note: When this parameter is set to true all other parameters except `files` and `additional_swiftlint_args` are ignored.
+
+```ruby
+swiftlint.lint_files(no_comment: true)
+
+# Now, you can handle the combined warnings + errors, or each separately commenting
+swiftlint.issues    # contains combined warnings + errors
+swiftlint.warnings  # just warnings
+swiftlint.errors    # just errors
+```
+
 You can use the `SWIFTLINT_VERSION` environment variable to override the default version installed via the `rake install` task.
 
 Finally, if something's not working correctly, you can debug this plugin by using setting `swiftlint.verbose = true`.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ swiftlint.lint_files(inline_mode: true) { |violation|
 }
 ```
 
-Or, by passing the `no_comment` parameter, you can completely manage the commenting of issues, warnings and errors yourself. An example usage might be using github reviews, or custom filtering logic. Note: When this parameter is set to true all other parameters except `files` and `additional_swiftlint_args` are ignored.
+Or, by passing the `no_comment` parameter, you can completely manage the commenting of issues, warnings and errors yourself. An example usage might be using GitHub reviews, or custom filtering logic. **Note**: When this parameter is set to `true`, all other parameters except `files` and `additional_swiftlint_args` are ignored.
 
 ```ruby
 swiftlint.lint_files(no_comment: true)

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -46,6 +46,9 @@ module Danger
 
     # Errors found
     attr_accessor :errors
+    
+    # All issues found
+    attr_accessor :issues
 
     # Lints Swift files. Will fail if `swiftlint` cannot be installed correctly.
     # Generates a `markdown` list of warnings for the prose in a corpus of
@@ -57,7 +60,7 @@ module Danger
     #          if nil, modified and added files from the diff will be used.
     # @return  [void]
     #
-    def lint_files(files = nil, inline_mode: false, fail_on_error: false, additional_swiftlint_args: '', &select_block)
+    def lint_files(files = nil, inline_mode: false, fail_on_error: false, additional_swiftlint_args: '', no_comment: false, &select_block)
       # Fails if swiftlint isn't installed
       raise 'swiftlint is not installed' unless swiftlint.installed?
 
@@ -101,8 +104,9 @@ module Danger
 
       # Lint each file and collect the results
       issues = run_swiftlint(files, lint_all_files, options, additional_swiftlint_args)
+      @issues = issues
       other_issues_count = 0
-      unless @max_num_violations.nil?
+      unless @max_num_violations.nil? || no_comment
         other_issues_count = issues.count - @max_num_violations if issues.count > @max_num_violations
         issues = issues.take(@max_num_violations)
       end
@@ -110,12 +114,15 @@ module Danger
       
       # filter out any unwanted violations with the passed in select_block
       if select_block
-        issues.select! { |issue| select_block.call(issue) }
+        issues = issues.select { |issue| select_block.call(issue) }
       end
 
       # Filter warnings and errors
       @warnings = issues.select { |issue| issue['severity'] == 'Warning' }
       @errors = issues.select { |issue| issue['severity'] == 'Error' }
+      
+      # Early exit so we don't comment
+      return if no_comment
 
       if inline_mode
         # Report with inline comment

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -113,7 +113,7 @@ module Danger
       log "Received from Swiftlint: #{issues}"
       
       # filter out any unwanted violations with the passed in select_block
-      if select_block
+      if select_block && !no_comment
         issues = issues.select { |issue| select_block.call(issue) }
       end
 

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -410,6 +410,58 @@ module Danger
             end
           end
         end
+          
+        context 'when no_comment is enabled' do
+          
+          it 'does not create comments' do
+            allow_any_instance_of(Swiftlint).to receive(:lint)
+              .with(hash_including(pwd: File.expand_path('.')), '')
+              .and_return(@swiftlint_multiviolation_response)
+
+            @swiftlint.lint_files(['spec/fixtures/some\ dir/SwiftFile.swift'], inline_mode: true, no_comment: true)
+            status = @swiftlint.status_report
+            expect(status[:warnings]).to eql([])
+            expect(status[:errors]).to eql([])
+            expect(status[:markdown]).to be_nil
+          end
+          
+          it 'does not filter with max_violations' do
+            allow_any_instance_of(Swiftlint).to receive(:lint)
+              .with(hash_including(pwd: File.expand_path('.')), '')
+              .and_return(@swiftlint_multiviolation_response)
+
+            @swiftlint.max_num_violations = 1
+            @swiftlint.lint_files(['spec/fixtures/some\ dir/SwiftFile.swift'], no_comment: true)
+            issues = @swiftlint.issues
+            expect(issues.length).to eql(2)
+          end
+          
+          it 'does not filter with select_block' do
+            allow_any_instance_of(Swiftlint).to receive(:lint)
+              .with(hash_including(pwd: File.expand_path('.')), '')
+              .and_return(@swiftlint_multiviolation_response)
+
+            @swiftlint.max_num_violations = 1
+            @swiftlint.lint_files(['spec/fixtures/some\ dir/SwiftFile.swift'], no_comment: true) { |v|
+              false
+            }
+            issues = @swiftlint.issues
+            expect(issues.length).to eql(2)
+          end
+          
+          it 'correctly sets issues, warnings, and errors accessors' do
+            allow_any_instance_of(Swiftlint).to receive(:lint)
+              .with(hash_including(pwd: File.expand_path('.')), '')
+              .and_return(@swiftlint_multiviolation_response)
+
+            @swiftlint.lint_files(['spec/fixtures/some\ dir/SwiftFile.swift'], no_comment: true)
+            issues = @swiftlint.issues
+            warnings = @swiftlint.warnings
+            errors = @swiftlint.errors
+            expect(issues.length).to eql(warnings.length + errors.length)
+          end
+        end
+        
 
         it 'parses environment variables set within the swiftlint config' do
           ENV['ENVIRONMENT_EXAMPLE'] = 'excluded_dir'


### PR DESCRIPTION
- An implementation of #129 
- Allows any caller of this library to extend handling of `issues`, `warnings` and `errors` in anyway they want.
- @ashfurrow 