### PR TITLE
Added support to filter issues found in git Diff

### DIFF
--- a/spec/fixtures/SwiftFile.diff
+++ b/spec/fixtures/SwiftFile.diff
@@ -1,0 +1,38 @@
+diff --git a/spec/fixtures/SwiftFile.swift b/spec/fixtures/SwiftFile.swift
+index 0e18440..9dda539 100755
+--- a/spec/fixtures/SwiftFile.swift
++++ b/spec/fixtures/SwiftFile.swift
+@@ -10,10 +10,33 @@ module Danger
+        // Hello, World! Program
+        import Swift
+        var tempString: String? = "Hello, World!"
+        print(tempString!)
+
++        var shoppingList = ["catfish", "water", "tulips"]
++        shoppingList[1] = "bottle of water"
++        
++        var occupations = [
++           "Malcolm": "Captain",
++           "Kaylee": "Mechanic",
++        ]
++        occupations["Jayne"] = "Public Relations"
++        
++        shoppingList.append("blue paint")
++        print(shoppingList)
++        
++        let individualScores = [75, 43, 103, 87, 12]
++        var teamScore = 0
++        for score in individualScores {
++           if score > 50 {
++               teamScore += 3
++           } else {
++               teamScore += 1
++           }
++        }
++        print(teamScore)
++        
+         var total = 0
+         for i in 0..<4 {
+            total += i
+         }
+         print(total)


### PR DESCRIPTION
To support reporting issues that were introduced in pull request changes, I have added a new attribute filter_issues_in_diff.
Setting this to true, will get all modified and added file info using git diff_for_file method for each file.

This will enable development team to set Danger rule for swiftlint to report only issues that were introduced in Pull Request . So, developer can focus on their issues instead of figuring out, was it introduced by developer who created the PR or it was an existing issue.