### PR TITLE
Fix guard for ext/swiftlint/swiftlint.rb

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -20,4 +20,7 @@ guard :rspec, cmd: 'bundle exec rspec' do
   # Ruby files
   ruby = dsl.ruby
   dsl.watch_spec_files_for(ruby.lib_files)
+
+  # Watch ext/swiftlint/*.rb files
+  dsl.watch_spec_files_for(%r{^ext/swiftlint/(.+)\.rb$})
 end


### PR DESCRIPTION
Changes to `ext/swiftlint/swiftlint.rb` don't trigger rspec when running guard. This fixes that by adding the `ext/swiftlint/` folder to the watch list, along with making sure the files are associated with their corresponding spec files.