### PR TITLE
Convert from using --path to using --use-script-input-files

### DIFF
--- a/spec/fixtures/multi_include.yml
+++ b/spec/fixtures/multi_include.yml
@@ -1,0 +1,6 @@
+disabled_rules:
+  - todo
+
+included:
+  - SwiftFile.swift
+  - some_dir/SwiftFile.swift

--- a/spec/swiftlint_spec.rb
+++ b/spec/swiftlint_spec.rb
@@ -40,4 +40,19 @@ describe Swiftlint do
                   cache_path: '/path',
                   enable_all_rules: true)
   end
+
+  it 'runs accepting options with env' do
+    cmd = 'swiftlint lint --no-use-stdin'
+    expect(swiftlint).to receive(:`).with(including(cmd))
+    expect(swiftlint).to receive(:update_env).with(
+      { 'SCRIPT_INPUT_FILE_COUNT' => '1',
+        'SCRIPT_INPUT_FILE_0' => 'File.swift' })
+    expect(swiftlint).to receive(:restore_env)
+
+    swiftlint.run('lint',
+                  '',
+                  { use_stdin: false },
+                  { 'SCRIPT_INPUT_FILE_COUNT' => '1',
+                    'SCRIPT_INPUT_FILE_0' => 'File.swift' })
+  end
 end


### PR DESCRIPTION
This converts from making a separate call to swiftlint for each file using `--path` to passing all files in at once using `--use-script-input-files`.

This is how [danger/swift](https://github.com/danger/swift/blob/3a859b894972d787f61b3e670548a779e0c283a7/Sources/Danger/Plugins/SwiftLint/SwiftLint.swift#L167) and [fastlane/swiftlint](https://github.com/fastlane/fastlane/blob/e76c03952dffa7d90ac244902e67170d4d48e922/fastlane/lib/fastlane/actions/swiftlint.rb#L31) do it and I believe it is the recommended way of linting specific files.

The biggest motivation for me for doing this is to allow nested configurations. Since passing a single file to swiftlint changes the "root folder" from the location of the main config file to the location of the swift file, swiftlint isn't able to traverse up the tree from the swift file up to the main config file looking for nested `.swiftlint.yml` files. By using `--use-script-input-files` instead of `--path`, swiftlint is able to find nested config files properly.

I suspect this change will have other benefits as well and could possibly have better performance.

Feel free to make or suggest any changes.

Closes #111 (and possibly related to #87)