### PR TITLE
Optimize performance of include/exclude test

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -216,6 +216,8 @@ module Danger
                 Dir.glob(files)
               end
       # Filter files to lint
+      excluded_paths_list = Find.find(*excluded_paths).to_a
+      included_paths_list = Find.find(*included_paths).to_a
       files.
         # Ensure only swift files are selected
         select { |file| file.end_with?('.swift') }.
@@ -226,12 +228,12 @@ module Danger
         # Ensure only files in the selected directory
         select { |file| file.start_with?(dir_selected) }.
         # Reject files excluded on configuration
-        reject { |file| file_exists?(excluded_paths, file) }.
+        reject { |file| excluded_paths_list.include?(file) }.
         # Accept files included on configuration
         select do |file|
-        next true if included_paths.empty?
-        file_exists?(included_paths, file)
-      end
+          next true if included_paths.empty?
+          included_paths_list.include?(file)
+        end
     end
 
     # Get the configuration file
@@ -253,16 +255,6 @@ module Danger
       file_contents.gsub(/\$\{([^{}]+)\}/) do |env_var|
         return env_var if ENV[Regexp.last_match[1]].nil?
         ENV[Regexp.last_match[1]]
-      end
-    end
-
-    # Return whether the file exists within a specified collection of paths
-    #
-    # @return [Bool] file exists within specified collection of paths
-    def file_exists?(paths, file)
-      paths.any? do |path|
-        Find.find(path)
-            .include?(file)
       end
     end
 


### PR DESCRIPTION
## Why?

On large codebases, the high number of calls to `Find.find` (which builds a recursive list of all files in directory and subdirectories) for every single file to lint (`Find.find` called on each iteration of the `reject {…}` and `select {…}` loops) ends up iterating on the whole file hierarchy multiple times, and affects performance.

## How?

Just stored the result of `Find.find(*excluded_path)` and `Find.find(*included_path)` in a local array so that it iterates only once, then used that pre-computed local array inside each iteration of `reject`/`select`

## Result

We just had a CircleCI timeout because of that performance issue, which made `swiftlint.lint_files` exceed the 10 minutes job timeout. On contrast, once pointing to this patch, the lint only took a few seconds.