### PR TITLE
Fix filter_issues_in_diff when diff contains removed lines above a violation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Current Master
 
-- Nothing yet!
+- Fix `filter_issues_in_diff` mode when diff contains removed lines above a violation. See [#147](https://github.com/ashfurrow/danger-ruby-swiftlint/pull/147)
 
 ## 0.24.2
 

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -354,8 +354,7 @@ module Danger
     def git_modified_lines(file)
       git_range_info_line_regex = /^@@ .+\+(?<line_number>\d+),/ 
       git_modified_line_regex = /^\+(?!\+|\+)/
-      git_removed_line_regex = /^[-]/
-      git_not_removed_line_regex = /^[^-]/
+      git_removed_line_regex = /^\-(?!\-|\-)/
       file_info = git.diff_for_file(file)
       line_number = 0
       lines = []
@@ -367,7 +366,7 @@ module Danger
           when git_modified_line_regex
               lines << line_number
           end
-          line_number += 1 if line_number > 0
+          line_number += 1 if line_number > 0 && !git_removed_line_regex.match?(line)
           line_number = starting_line_number if line_number == 0 && starting_line_number > 0
       end
       lines

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -419,7 +419,8 @@ module Danger
           allow(@swiftlint.git.diff_for_file).to receive(:patch).and_return(git_diff)
           modified_lines = @swiftlint.git_modified_lines("spec/fixtures/SwiftFile.swift")
           expect(modified_lines).to_not be_empty
-          expect(modified_lines.length).to eql(23)
+          expect(modified_lines.length).to eql(24)
+          expect(modified_lines).to eql([15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 42])
         end
 
         it 'Get git modified files info' do

--- a/spec/fixtures/SwiftFile.diff
+++ b/spec/fixtures/SwiftFile.diff
@@ -35,4 +35,5 @@ index 0e18440..9dda539 100755
          for i in 0..<4 {
             total += i
          }
-         print(total)
+-        print(total)
++        print("Total:", total)


### PR DESCRIPTION
This is a kind of bug report while I work to figuring out a solution (but am struggling a bit so far). 

We noticed that while using `filter_issues_in_diff`, sometimes violations were not being flagged and as a result some issues would sneak past code review... I've finally got around to diving in to see what is going wrong and it looks like the `git_modified_lines` is miscomputing the line numbers from a diff so the issues are being skipped by mistake. 

So far, I've updated **spec/fixtures/SwiftFile.diff** to reproduce the issue by replacing line 42 (`print(total)`) with (`print("Total:", total)`). I've then updated the spec to check the line numbers reported and can confirm that it's incorrectly being reported as line 43.

There isn't much test coverage around this so I'm being careful, but I think we need to decrement `line_number` when matching against `git_removed_line_regex`? I'll have a poke around to see if I can come up with a solution or not but if not, I might need a hand 🙏 