### PR TITLE
Update SwiftLint to 0.40.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,8 @@
 
 ## Current Master
 
-## Nothing yet!
+- Updates to SwiftLint
+  [0.40.1](https://github.com/realm/SwiftLint/releases/tag/0.40.1).
 
 ## 0.24.3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## Current Master
 
+## Nothing yet!
+
+## 0.24.4
+
 - Updates to SwiftLint
   [0.40.1](https://github.com/realm/SwiftLint/releases/tag/0.40.1).
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-swiftlint (0.24.3)
+    danger-swiftlint (0.24.4)
       danger
       rake (> 10)
       thor (~> 0.19)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module DangerSwiftlint
-  VERSION = '0.24.3'
+  VERSION = '0.24.4'
   SWIFTLINT_VERSION = '0.40.1'
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,5 +2,5 @@
 
 module DangerSwiftlint
   VERSION = '0.24.3'
-  SWIFTLINT_VERSION = '0.39.1'
+  SWIFTLINT_VERSION = '0.40.1'
 end


### PR DESCRIPTION
This updates the SwiftLint version to `0.40.1`. This includes the following releases:

- https://github.com/realm/SwiftLint/releases/tag/0.39.2
- https://github.com/realm/SwiftLint/releases/tag/0.40.0
- https://github.com/realm/SwiftLint/releases/tag/0.40.1

 