### PR TITLE
Don’t pass explicit config if lint_all_files: true

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -69,7 +69,7 @@ module Danger
 
       config_file_path = if config_file
                            config_file
-                         elsif File.file?('.swiftlint.yml')
+                         elsif !lint_all_files && File.file?('.swiftlint.yml')
                            File.expand_path('.swiftlint.yml')
                          end
       log "Using config file: #{config_file_path}"


### PR DESCRIPTION
SwiftLint 0.41.0 introduces a breaking change when handling `—config` and nested configs: https://github.com/realm/SwiftLint/issues/3417

I've only changed the behavior when `lint_all_files = true` to be more cautious - SwiftLint's config handling is a landmine and I'm afraid of breaking something when linting individual files 