### PR TITLE
Improved `config-file` handling to match SwiftLint's expected behavior.

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -46,7 +46,7 @@ module Danger
 
     # Errors found
     attr_accessor :errors
-    
+
     # All issues found
     attr_accessor :issues
 
@@ -67,12 +67,12 @@ module Danger
       # Fails if swiftlint isn't installed
       raise 'swiftlint is not installed' unless swiftlint.installed?
 
-      config_file_path = if config_file
-                           config_file
-                         elsif !lint_all_files && File.file?('.swiftlint.yml')
-                           File.expand_path('.swiftlint.yml')
-                         end
-      log "Using config file: #{config_file_path}"
+      config_file_path = config_file
+      if config_file_path
+        log "Using config file: #{config_file_path}"
+      else
+        log 'Config file was not specified.'
+      end
 
       dir_selected = directory ? File.expand_path(directory) : Dir.pwd
       log "Swiftlint will be run from #{dir_selected}"
@@ -124,7 +124,7 @@ module Danger
         issues = issues.take(@max_num_violations)
       end
       log "Received from Swiftlint: #{issues}"
-      
+
       # filter out any unwanted violations with the passed in select_block
       if select_block && !no_comment
         issues = issues.select { |issue| select_block.call(issue) }
@@ -133,7 +133,7 @@ module Danger
       # Filter warnings and errors
       @warnings = issues.select { |issue| issue['severity'] == 'Warning' }
       @errors = issues.select { |issue| issue['severity'] == 'Error' }
-      
+
       # Early exit so we don't comment
       return if no_comment
 

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -314,24 +314,6 @@ module Danger
           @swiftlint.lint_files
         end
 
-        it 'expands default config file (if present) to absolute path' do
-          allow(@swiftlint.git).to receive(:added_files).and_return([])
-          allow(@swiftlint.git).to receive(:modified_files).and_return([
-                                                                         'spec/fixtures/SwiftFile.swift'
-                                                                       ])
-          expect(File).to receive(:file?).and_return(true)
-          expect(File).to receive(:exist?).and_return(true)
-          expect(File).to receive(:open).and_return(StringIO.new)
-          expect(YAML).to receive(:safe_load).and_return({})
-
-          expect_any_instance_of(Swiftlint).to receive(:lint)
-            .with(hash_including(config: File.expand_path('.swiftlint.yml')), '', anything)
-            .once
-            .and_return(@swiftlint_response)
-
-          @swiftlint.lint_files
-        end
-
         it 'expands specified config file to absolute path' do
           allow(@swiftlint.git).to receive(:added_files).and_return([])
           allow(@swiftlint.git).to receive(:modified_files).and_return([


### PR DESCRIPTION
This fixes #160 by not providing a default `config_file`. Instead it lets SwiftLint handle unspecified config files.

Users that explicitly provided a `config_file` should not see any changes.