### PR TITLE
feat: swiftlint version update for inclusive_language allowance list support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 ## Nothing yet!
 
-- Nothing yet!
+- Update SwiftLint to 0.43.1 for inclusive_language allowance list support. See [#165](https://github.com/ashfurrow/danger-ruby-swiftlint/issues/165).
 
 ## 0.26.0
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,5 +2,5 @@
 
 module DangerSwiftlint
   VERSION = '0.26.0'
-  SWIFTLINT_VERSION = '0.41.0'
+  SWIFTLINT_VERSION = '0.43.1'
 end


### PR DESCRIPTION
swiftlint version update for inclusive_language allowance list support

https://github.com/ashfurrow/danger-ruby-swiftlint/issues/165