### PR TITLE
Fix a crash caused by accessing renamed/moved files by their old filepaths

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -210,11 +210,13 @@ module Danger
     # @return [Array] swift files
     def find_swift_files(dir_selected, files = nil, excluded_paths = [], included_paths = [])
       # Assign files to lint
-      files = if files.nil?
-                (git.modified_files - git.deleted_files) + git.added_files
-              else
-                Dir.glob(files)
-              end
+      if files.nil?
+        renamed_files_hash = git.renamed_files.map { |rename| [rename[:before], rename[:after]] }.to_h
+        post_rename_modified_files = git.modified_files.map { |modified_file| renamed_files_hash[modified_file] || modified_file }
+        files = (post_rename_modified_files - git.deleted_files) + git.added_files
+      else
+        files = Dir.glob(files)
+      end
       # Filter files to lint
       excluded_paths_list = Find.find(*excluded_paths).to_a
       included_paths_list = Find.find(*included_paths).to_a

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -143,6 +143,7 @@ module Danger
         it 'uses git diff when files are not provided' do
           allow(@swiftlint.git).to receive(:modified_files).and_return(['spec/fixtures/SwiftFile.swift'])
           allow(@swiftlint.git).to receive(:added_files).and_return([])
+          allow(@swiftlint.git).to receive(:renamed_files).and_return([])
           allow_any_instance_of(Swiftlint).to receive(:lint)
             .with(anything, '',
               { 'SCRIPT_INPUT_FILE_COUNT' => '1',
@@ -187,6 +188,7 @@ module Danger
                                                                          'spec/fixtures/some_dir/SwiftFile.swift',
                                                                          'spec/fixtures/SwiftFile.swift'
                                                                        ])
+          allow(@swiftlint.git).to receive(:renamed_files).and_return([])
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
             .with(anything, '',
@@ -212,6 +214,7 @@ module Danger
           # JSON object.
 
           allow_any_instance_of(Swiftlint).to receive(:lint).and_return('')
+          allow(@swiftlint.git).to receive(:renamed_files).and_return([])
 
           expect { @swiftlint.lint_files }.not_to raise_error
         end
@@ -223,7 +226,7 @@ module Danger
                                                                          'spec/fixtures/excluded_dir/SwiftFileThatShouldNotBeIncluded.swift',
                                                                          'spec/fixtures/excluded_dir/SwiftFile WithEscaped+CharactersThatShouldNotBeIncluded.swift'
                                                                        ])
-
+          allow(@swiftlint.git).to receive(:renamed_files).and_return([])
           expect_any_instance_of(Swiftlint).to receive(:lint)
             .with(anything, '',
               { 'SCRIPT_INPUT_FILE_COUNT' => '1',
@@ -241,6 +244,7 @@ module Danger
                                                                          'spec/fixtures/SwiftFile.swift',
                                                                          'spec/fixtures/some_dir/SwiftFile.swift'
                                                                        ])
+          allow(@swiftlint.git).to receive(:renamed_files).and_return([])
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
             .with(anything, '',
@@ -259,6 +263,7 @@ module Danger
                                                                          'spec/fixtures/SwiftFile.swift',
                                                                          'spec/fixtures/some_dir/SwiftFile.swift'
                                                                        ])
+          allow(@swiftlint.git).to receive(:renamed_files).and_return([])
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
             .with(anything, '',
@@ -277,6 +282,7 @@ module Danger
           allow(@swiftlint.git).to receive(:modified_files).and_return([
                                                                          'spec/fixtures/SwiftFile.swift'
                                                                        ])
+          allow(@swiftlint.git).to receive(:renamed_files).and_return([])
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
             .once
@@ -291,6 +297,7 @@ module Danger
           allow(@swiftlint.git).to receive(:modified_files).and_return([
                                                                          'spec/fixtures/SwiftFile.swift'
                                                                        ])
+          allow(@swiftlint.git).to receive(:renamed_files).and_return([])
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
             .once
@@ -305,6 +312,7 @@ module Danger
           allow(@swiftlint.git).to receive(:modified_files).and_return([
                                                                          'spec/fixtures/SwiftFile.swift'
                                                                        ])
+          allow(@swiftlint.git).to receive(:renamed_files).and_return([])
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
             .with(hash_including(config: nil), '', anything)
@@ -319,6 +327,7 @@ module Danger
           allow(@swiftlint.git).to receive(:modified_files).and_return([
                                                                          'spec/fixtures/SwiftFile.swift'
                                                                        ])
+          allow(@swiftlint.git).to receive(:renamed_files).and_return([])
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
             .with(hash_including(config: 'spec/fixtures/some_config.yml'), '', anything)
@@ -342,6 +351,7 @@ module Danger
           allow(@swiftlint.git).to receive(:deleted_files).and_return([
                                                                         'spec/fixtures/DeletedFile.swift'
                                                                       ])
+          allow(@swiftlint.git).to receive(:renamed_files).and_return([])
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
             .with(anything, '',
@@ -578,6 +588,7 @@ module Danger
                                                                          'spec/fixtures/excluded_dir/SwiftFileThatShouldNotBeIncluded.swift',
                                                                          'spec/fixtures/excluded_dir/SwiftFile WithEscaped+CharactersThatShouldNotBeIncluded.swift'
                                                                        ])
+          allow(@swiftlint.git).to receive(:renamed_files).and_return([])
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
             .once

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -219,6 +219,24 @@ module Danger
           expect { @swiftlint.lint_files }.not_to raise_error
         end
 
+        it 'crashes if renamed_files is not configured properly' do
+          allow(@swiftlint.git).to receive(:modified_files).and_return([
+                                                                         'spec/fixtures/SwiftFileThatWasRenamedToSomethingElse.swift'
+                                                                       ])
+          expect { @swiftlint.lint_files }.to raise_error(NoMethodError)
+        end
+
+        it 'does not crash if a modified file was renamed' do
+          allow(@swiftlint.git).to receive(:modified_files).and_return([
+                                                                         'spec/fixtures/SwiftFileThatWasRenamedToSomethingElse.swift'
+                                                                       ])
+          allow(@swiftlint.git).to receive(:renamed_files).and_return([
+                                                                        { before: 'spec/fixtures/SwiftFileThatWasRenamedToSomethingElse.swift',
+                                                                          after: 'spec/fixtures/SwiftFile.swift' }
+                                                                      ])
+          expect { @swiftlint.lint_files }.not_to raise_error
+        end
+
         it 'does not lint files in the excluded paths' do
           allow(@swiftlint.git).to receive(:added_files).and_return([])
           allow(@swiftlint.git).to receive(:modified_files).and_return([


### PR DESCRIPTION
## Description

Resolves #168

I shamelessly copied the strategy implemented by a similar linter: https://github.com/garriguv/danger-ruby-swiftformat/blob/8915b65a9b17d26c80cd9c5caa08cb3cf2bafefa/lib/swiftformat/plugin.rb#L82-L87

Tested on my project by pointing my Gemfile to my local clone and it works perfectly 💪 