### PR TITLE
Fix "Rake aborted; Command failed with status 127" (#162)

### DIFF
--- a/ext/swiftlint/Rakefile
+++ b/ext/swiftlint/Rakefile
@@ -15,7 +15,7 @@ namespace :swiftlint do
     SWIFTLINT_MD5_HASH = DangerSwiftlint::SWIFTLINT_HASH
 
     puts "Downloading swiftlint@#{VERSION}"
-    sh "./downloadSwiftlint.sh -u #{URL} -d #{DESTINATION} -a #{ASSET} -dh #{SWIFTLINT_MD5_HASH}"
+    sh "sh downloadSwiftlint.sh -u #{URL} -d #{DESTINATION} -a #{ASSET} -dh #{SWIFTLINT_MD5_HASH}"
   end
 end
 


### PR DESCRIPTION
<img width="1440" alt="Screen Shot 2021-09-07 at 09 36 52" src="https://user-images.githubusercontent.com/42418337/132383251-97ad9d1d-34bc-4f33-ae78-6b05ca1f3950.png">

`rake swiftlint:install` task was failing due to a `Command failed with status 127` error.

This pull request fixes that, I tested it by running `bundle update danger-swiftlint` , targeting `gem 'danger-swiftlint', git: 'git@github.com:NicolasCombe5555/danger-ruby-swiftlint.git', branch: 'master'`

[similar-issue](http://otaku-elite.com/blog/2013/06/06/rake-status-127/)