### PR TITLE
Don't rely on the swiftlint executable for tests.

### DIFF
--- a/ext/swiftlint/Rakefile
+++ b/ext/swiftlint/Rakefile
@@ -16,7 +16,7 @@ namespace :swiftlint do
     SWIFTLINT_MD5_HASH = DangerSwiftlint::SWIFTLINT_HASH
 
     puts "Downloading swiftlint@#{VERSION}"
-    sh "bash #{SCRIPT_PATH}/downloadSwiftlint.sh -u #{URL} -d #{DESTINATION} -a #{ASSET} -dh #{SWIFTLINT_MD5_HASH}"
+    sh "#{SCRIPT_PATH}/downloadSwiftlint.sh -u #{URL} -d #{DESTINATION} -a #{ASSET} -dh #{SWIFTLINT_MD5_HASH}"
   end
 end
 

--- a/ext/swiftlint/Rakefile
+++ b/ext/swiftlint/Rakefile
@@ -16,7 +16,7 @@ namespace :swiftlint do
     SWIFTLINT_MD5_HASH = DangerSwiftlint::SWIFTLINT_HASH
 
     puts "Downloading swiftlint@#{VERSION}"
-    sh "sh #{SCRIPT_PATH}/downloadSwiftlint.sh -u #{URL} -d #{DESTINATION} -a #{ASSET} -dh #{SWIFTLINT_MD5_HASH}"
+    sh "bash #{SCRIPT_PATH}/downloadSwiftlint.sh -u #{URL} -d #{DESTINATION} -a #{ASSET} -dh #{SWIFTLINT_MD5_HASH}"
   end
 end
 

--- a/ext/swiftlint/downloadSwiftlint.sh
+++ b/ext/swiftlint/downloadSwiftlint.sh
@@ -31,8 +31,6 @@ do
     shift
 done
 
-set -x
-
 ### Download
 mkdir -p "${destination}"
 curl -s -L "${url}" -o "${asset}"

--- a/ext/swiftlint/downloadSwiftlint.sh
+++ b/ext/swiftlint/downloadSwiftlint.sh
@@ -33,18 +33,19 @@ done
 
 set -x
 
-# If macOS
-if [[ "$OSTYPE" == "darwin"* ]]; then
-   hash_cmd="md5 -q ${asset}"
-# Default to linux
-else
-   hash_cmd="md5sum ${asset} | awk '{ print $1 }'"
-fi
-
 ### Download
 mkdir -p "${destination}"
 curl -s -L "${url}" -o "${asset}"
-if [[ ! -z "${SWIFTLINT_VERSION}" || "$hash_cmd" == "${default_hash}" ]]; then
+
+# If macOS
+if [[ "$OSTYPE" == "darwin"* ]]; then
+   resulting_hash=`md5 -q ${asset}`
+# Default to linux
+else
+   resulting_hash=`md5sum ${asset} | awk '{ print $1 }'`
+fi
+
+if [[ ! -z "${SWIFTLINT_VERSION}" || "$resulting_hash" == "${default_hash}" ]]; then
   # if another version is set || our hardcoded hash is correct
   unzip -o -q "${asset}" -d "${destination}"
 else

--- a/ext/swiftlint/downloadSwiftlint.sh
+++ b/ext/swiftlint/downloadSwiftlint.sh
@@ -31,6 +31,8 @@ do
     shift
 done
 
+set -x
+
 # If macOS
 if [[ "$OSTYPE" == "darwin"* ]]; then
    hash_cmd="md5 -q ${asset}"

--- a/ext/swiftlint/downloadSwiftlint.sh
+++ b/ext/swiftlint/downloadSwiftlint.sh
@@ -31,10 +31,18 @@ do
     shift
 done
 
+# If macOS
+if [[ "$OSTYPE" == "darwin"* ]]; then
+   hash_cmd="md5 -q ${asset}"
+# Default to linux
+else
+   hash_cmd="md5sum ${asset} | awk '{ print $1 }'"
+fi
+
 ### Download
 mkdir -p "${destination}"
 curl -s -L "${url}" -o "${asset}"
-if [[ ! -z "${SWIFTLINT_VERSION}" || $(md5 -q "${asset}") == "${default_hash}" ]]; then
+if [[ ! -z "${SWIFTLINT_VERSION}" || "$hash_cmd" == "${default_hash}" ]]; then
   # if another version is set || our hardcoded hash is correct
   unzip -o -q "${asset}" -d "${destination}"
 else

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -220,6 +220,7 @@ module Danger
         end
 
         it 'crashes if renamed_files is not configured properly' do
+          allow_any_instance_of(Swiftlint).to receive(:lint).and_return('')
           allow(@swiftlint.git).to receive(:modified_files).and_return([
                                                                          'spec/fixtures/SwiftFileThatWasRenamedToSomethingElse.swift'
                                                                        ])
@@ -227,6 +228,7 @@ module Danger
         end
 
         it 'does not crash if a modified file was renamed' do
+          allow_any_instance_of(Swiftlint).to receive(:lint).and_return('')
           allow(@swiftlint.git).to receive(:modified_files).and_return([
                                                                          'spec/fixtures/SwiftFileThatWasRenamedToSomethingElse.swift'
                                                                        ])


### PR DESCRIPTION
CI is raising this error
```
expected no Exception, got #<Errno::ENOENT: No such file or directory - /home/travis/build/ashfurrow/danger-ruby-swiftlint/ext/swiftlint/bin/swiftlint> with backtrace:
```

It seems like it is trying to find the `swiftlint` executable to lint the renamed file. This line fixes it:
```
allow_any_instance_of(Swiftlint).to receive(:lint).and_return('')
```
Fixes #171