### PR TITLE
Update SwiftLint version to 0.46.2

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,6 +2,6 @@
 
 module DangerSwiftlint
   VERSION = '0.29.4'
-  SWIFTLINT_VERSION = '0.43.1'
+  SWIFTLINT_VERSION = '0.46.2'
   SWIFTLINT_HASH = '4eaeabbb43b308975d16e3d9869880dc'
 end


### PR DESCRIPTION
As the SwiftLint version used by the plugin got outdated, it started introducing discrepancies between our local builds and the report from Danger. (we would fix a warning locally, but it still pops up in Danger because of an older version of the rule).

I think it's warranted to update the swiftlint version as opposed to manually inject the SWIFTLINT_VERSION env var for a version more recent than the plugin.

I'm of course open to suggestions, in case anything else also needs changes to make this work 😅.