### PR TITLE
Fix mismatched SwiftLint hash

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-swiftlint (0.29.4)
+    danger-swiftlint (0.30.0)
       danger
       rake (> 10)
       thor (~> 0.19)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -3,5 +3,5 @@
 module DangerSwiftlint
   VERSION = '0.30.0'
   SWIFTLINT_VERSION = '0.46.2'
-  SWIFTLINT_HASH = '4eaeabbb43b308975d16e3d9869880dc'
+  SWIFTLINT_HASH = '20dbcc13788993dd27b1076a13ca647d'
 end


### PR DESCRIPTION
In my last PR #176, I forgot to update the `SWIFTLINT_HASH` env var, causing crashes in the current version (as mentioned in #178).

As far as I could test, the current change fixes the issue, as it now matches the md5 hash of https://github.com/realm/SwiftLint/releases/download/0.46.2/portable_swiftlint.zip 
