### PR TITLE
Fix `git_modified_lines` method

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -369,7 +369,7 @@ module Danger
               lines << line_number
           end
           line_number += 1 if line_number > 0 && !git_removed_line_regex.match?(line)
-          line_number = starting_line_number if line_number == 0 && starting_line_number > 0
+          line_number = starting_line_number if starting_line_number > 0
       end
       lines
     end

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -431,8 +431,8 @@ module Danger
           allow(@swiftlint.git.diff_for_file).to receive(:patch).and_return(git_diff)
           modified_lines = @swiftlint.git_modified_lines("spec/fixtures/SwiftFile.swift")
           expect(modified_lines).to_not be_empty
-          expect(modified_lines.length).to eql(24)
-          expect(modified_lines).to eql([15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 42])
+          expect(modified_lines.length).to eql(28)
+          expect(modified_lines).to eql([15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 42, 64, 65, 66, 67])
         end
 
         it 'Get git modified files info' do

--- a/spec/fixtures/SwiftFile.diff
+++ b/spec/fixtures/SwiftFile.diff
@@ -37,3 +37,12 @@ index 0e18440..9dda539 100755
          }
 -        print(total)
 +        print("Total:", total)
+@@ -38,4 +61,8 @@ let rooms = ["2_101", "2_102", "2_103"] {
+     rooms.append("3_102")
+     rooms.append("3_104")
+     rooms.append("3_105")
++
++    // Add 1st floor
++    rooms.append("1_231")
++    rooms.append("1_201")
+     print(rooms)


### PR DESCRIPTION
**What**
Update `git_modified_lines` method to properly parse multipart `git diff`

**Why**
It looks like it wrongly counts modified lines when `git diff` has multiple parts with more lines matching 
```
/^@@ .+\+(?<line_number>\d+),/ 
```