### PR TITLE
Add feature to track renamed files

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -53,6 +53,9 @@ module Danger
     # Whether all issues or ones in PR Diff to be reported
     attr_accessor :filter_issues_in_diff
 
+    # Whether including renamed files
+    attr_accessor :track_renames
+
     # Lints Swift files. Will fail if `swiftlint` cannot be installed correctly.
     # Generates a `markdown` list of warnings for the prose in a corpus of
     # .markdown and .md files.
@@ -214,6 +217,7 @@ module Danger
         renamed_files_hash = git.renamed_files.map { |rename| [rename[:before], rename[:after]] }.to_h
         post_rename_modified_files = git.modified_files.map { |modified_file| renamed_files_hash[modified_file] || modified_file }
         files = (post_rename_modified_files - git.deleted_files) + git.added_files
+        files += git.renamed_files if track_renames
       else
         files = Dir.glob(files)
       end
@@ -343,6 +347,7 @@ module Danger
     def git_modified_files_info()
         modified_files_info = Hash.new
         updated_files = (git.modified_files - git.deleted_files) + git.added_files
+        updated_files += git.renamed_files if track_renames
         updated_files.each {|file|
             modified_lines = git_modified_lines(file)
             modified_files_info[File.expand_path(file)] = modified_lines

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -487,6 +487,39 @@ module Danger
           expect(status[:warnings]).to eql(["Force casts should be avoided.\n`force_cast` `SwiftFile.swift:16`"])
         end
 
+        it 'issues violations in renamed_files' do
+          allow(@swiftlint.git).to receive(:added_files).and_return([])
+          allow(@swiftlint.git).to receive(:modified_files).and_return([])
+          allow(@swiftlint.git).to receive(:deleted_files).and_return([])
+          renamed_info = {
+            before: "spec/fixtures/BeforeRenamedSwiftFile.swift",
+            after: "spec/fixtures/SwiftFile.swift"
+          }
+          allow(@swiftlint.git).to receive(:renamed_files).and_return([renamed_info])
+          git_diff = File.read("spec/fixtures/SwiftFile.diff")
+          allow(@swiftlint.git).to receive(:diff_for_file).and_return(git_diff)
+          allow(@swiftlint.git.diff_for_file).to receive(:patch).and_return(git_diff)
+
+          swiftlint_violations_response = '[{ "rule_id" : "force_cast", "reason" : "Force casts should be avoided.", "character" : 19, "file" : "/Users/me/this_repo/spec/fixtures/SwiftFile.swift", "severity" : "Error", "type" : "Force Cast", "line" : 14 },
+                                                 { "rule_id" : "force_cast", "reason" : "Force casts should be avoided.", "character" : 10, "file" : "/Users/me/this_repo/spec/fixtures/SwiftFile.swift", "severity" : "Error", "type" : "Force Cast", "line" : 16 }]'
+
+          violations_json = JSON.parse(swiftlint_violations_response)
+          violations_json[0][:file] = File.expand_path('spec/fixtures/SwiftFile.swift')
+          violations_json[1][:file] = File.expand_path('spec/fixtures/SwiftFile.swift')
+          swiftlint_violations_response= violations_json.to_json
+          allow_any_instance_of(Swiftlint).to receive(:lint)
+                                                .with(anything, '',
+                                                      { 'SCRIPT_INPUT_FILE_COUNT' => '1',
+                                                        'SCRIPT_INPUT_FILE_0' => a_string_ending_with('spec/fixtures/SwiftFile.swift') })
+                                                .and_return(swiftlint_violations_response)
+
+          @swiftlint.filter_issues_in_diff = true
+          @swiftlint.lint_files('spec/fixtures/*.swift', inline_mode: true, fail_on_error: false, additional_swiftlint_args: '')
+
+          status = @swiftlint.status_report
+          expect(status[:warnings]).to eql(["Force casts should be avoided.\n`force_cast` `SwiftFile.swift:16`"])
+        end
+
         context '#strict' do
           before(:each) do
             allow_any_instance_of(Swiftlint).to receive(:lint)

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -444,6 +444,7 @@ module Danger
           allow(@swiftlint.git).to receive(:deleted_files).and_return([
                                                                         'spec/fixtures/DeletedFile.swift'
                                                                       ])
+          allow(@swiftlint.git).to receive(:renamed_files).and_return([])
           git_diff = File.read("spec/fixtures/SwiftFile.diff")
           allow(@swiftlint.git).to receive(:diff_for_file).and_return(git_diff)
           allow(@swiftlint.git.diff_for_file).to receive(:patch).and_return(git_diff)
@@ -461,6 +462,7 @@ module Danger
           allow(@swiftlint.git).to receive(:deleted_files).and_return([
                                                                         'spec/fixtures/DeletedFile.swift'
                                                                       ])
+          allow(@swiftlint.git).to receive(:renamed_files).and_return([])
           git_diff = File.read("spec/fixtures/SwiftFile.diff")
           allow(@swiftlint.git).to receive(:diff_for_file).and_return(git_diff)
           allow(@swiftlint.git.diff_for_file).to receive(:patch).and_return(git_diff)


### PR DESCRIPTION

If files are renamed and modified, violations in the file are not issued in the current implementation.

This PR enables the issue of the violation in the file to be renamed.