### PR TITLE
Add GitHub Actions CI for spec and rubocop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  spec:
+    name: RSpec
+    runs-on: ubuntu-latest
+    env:
+      DANGER_SKIP_SWIFTLINT_INSTALL: 'YES'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle exec rake spec
+
+  # FIXME: rubocop is pinned to Ruby 2.7 because the gem is pinned at ~> 0.50.0
+  # (2017) and won't load on Ruby 3.x (parser/racc, Psych 4). Bump rubocop to a
+  # modern release ASAP and drop this `ruby-version` override.
+  rubocop:
+    name: RuboCop
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+          bundler-cache: true
+      - run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,12 @@
+# FIXME: rubocop is pinned at ~> 0.50.0 (released 2017) and its `TargetRubyVersion`
+# table maxes out at Ruby 2.4. Modern Ruby (3.x) also breaks the gem's parser/Psych
+# dependencies. To keep the linter running in CI we force the target down to 2.4
+# and pin the rubocop job to Ruby 2.7 (the newest version where 0.50.0 still
+# loads). This is a temporary band-aid: bump rubocop to a modern release ASAP
+# and remove this block (and the Ruby pin in .github/workflows/ci.yml).
+AllCops:
+  TargetRubyVersion: 2.4
+
 # Disable linting of Dangerfile.
 Style/FrozenStringLiteralComment:
   Exclude:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-swiftlint (0.37.4)
+    danger-swiftlint (0.37.5)
       danger
       rake (> 10)
       thor (~> 1.4)


### PR DESCRIPTION
Closes #213 by adding GitHub Actions.

I went ahead and did it rather than open a discussion regarding which provider to use because setting up GHA is so simple that we can let the PR and code talk by themselves. If GHA is not a favorite, then feel free to close the PR.

I added two steps: for RSpec and for RuboCop. The RuboCop step fail because I didn't want to bloat this PR. Additionally, RuboCop is on a rather old version that is not compatible with Ruby 3.x. Addressing the violations should also include upgrading to latest version.