### PR TITLE
Bump minimum Ruby supported to 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby: ['3.3', '3.4']
     env:
       DANGER_SKIP_SWIFTLINT_INSTALL: 'YES'
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.4.5
   NewCops: disable
 
 # Disable linting of Dangerfile.

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Current Master
 
-- Dropped support for Ruby 3.0, 3.1, and 3.2. See #216
+- Dropped support for Ruby 3.0, 3.1, and 3.2. See [#216](https://github.com/ashfurrow/danger-ruby-swiftlint/pull/216)
 
 ## 0.37.5
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Current Master
 
-- Nothing yet!
+- Dropped support for Ruby 3.0, 3.1, and 3.2. See #216
 
 ## 0.37.5
 
@@ -35,7 +35,7 @@
 
 ## 0.35.0
 
-- Updates Thor to 1.0.0. 
+- Updates Thor to 1.0.0.
 
 ## 0.34.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,7 @@ group :development do
   gem 'bundler'
   gem 'mocha'
   gem 'mocha-on-bacon'
-  # `parallel` 2.x requires Ruby >= 3.3 — keep it on 1.x so the matrix
-  # can still install on Ruby 3.0–3.2.
-  gem 'parallel', '< 2'
+  gem 'parallel'
   gem 'prettybacon'
   gem 'rubocop', '~> 1.50', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
       sawyer (~> 0.9)
     open4 (1.3.4)
     ostruct (0.6.3)
-    parallel (1.28.0)
+    parallel (2.1.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
@@ -168,7 +168,7 @@ DEPENDENCIES
   listen (= 3.0.7)
   mocha
   mocha-on-bacon
-  parallel (< 2)
+  parallel
   prettybacon
   pry
   rspec (~> 3.4)

--- a/danger-swiftlint.gemspec
+++ b/danger-swiftlint.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.extensions    = %w[ext/swiftlint/Rakefile]
   spec.executables   = ['danger-swiftlint']
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 3.3'
 
   spec.add_dependency 'danger'
   spec.add_dependency 'rake', '> 10'


### PR DESCRIPTION
Follow up to
https://github.com/ashfurrow/danger-ruby-swiftlint/pull/215#discussion_r3301712218, which highlighted Ruby versions < 3.3 are no longer receiving support.